### PR TITLE
Fix #482 Add logout endpoint

### DIFF
--- a/internal/handler/v2/onboard/onboard_logout_user.go
+++ b/internal/handler/v2/onboard/onboard_logout_user.go
@@ -1,0 +1,77 @@
+package onboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/asaskevich/govalidator"
+	"github.com/bb-consent/api/internal/actionlog"
+	"github.com/bb-consent/api/internal/common"
+	"github.com/bb-consent/api/internal/config"
+	"github.com/bb-consent/api/internal/iam"
+	"github.com/bb-consent/api/internal/individual"
+	"github.com/bb-consent/api/internal/token"
+	"github.com/bb-consent/api/internal/user"
+)
+
+// logoutUser
+func logoutUser(accessToken string, refreshToken string, iamId string, organisationId string) error {
+
+	orgAdmin, err := user.GetByIamID(iamId)
+	if err != nil {
+		// Repository
+		individualRepo := individual.IndividualRepository{}
+		individualRepo.Init(organisationId)
+
+		_, err := individualRepo.GetByIamID(iamId)
+		if err != nil {
+			return err
+		}
+
+	}
+	iam.LogoutUser(accessToken, refreshToken)
+	// log security calls
+	if len(orgAdmin.Roles) > 0 {
+		actionLog := fmt.Sprintf("%v logged out", orgAdmin.Email)
+		actionlog.LogOrgSecurityCalls(orgAdmin.ID.Hex(), orgAdmin.Email, organisationId, actionLog)
+	}
+	return nil
+}
+
+type logoutReq struct {
+	RefreshToken string `json:"refreshToken" valid:"required"`
+}
+
+// OnboardLogoutUser Logouts a user
+func OnboardLogoutUser(w http.ResponseWriter, r *http.Request) {
+	organisationId := r.Header.Get(config.OrganizationId)
+
+	var lReq logoutReq
+	b, _ := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
+	json.Unmarshal(b, &lReq)
+
+	// validating request payload for logout
+	valid, err := govalidator.ValidateStruct(lReq)
+	if !valid {
+		m := "Missing mandatory param refresh token"
+		common.HandleError(w, http.StatusBadRequest, m, err)
+		return
+	}
+	headerType, accessToken, err := token.DecodeAuthHeader(r)
+
+	if headerType != token.AuthorizationToken {
+		m := "Failed to logout user"
+		common.HandleError(w, http.StatusBadRequest, m, err)
+		return
+	}
+
+	iamId := token.GetIamID(r)
+
+	// logout user
+	logoutUser(accessToken, lReq.RefreshToken, iamId, organisationId)
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/http_path/v2/onboard_paths.go
+++ b/internal/http_path/v2/onboard_paths.go
@@ -3,6 +3,7 @@ package http_path
 // login
 const LoginAdminUser = "/v2/onboard/admin/login"
 const LoginUser = "/v2/onboard/individual/login"
+const OnboardLogoutUser = "/v2/onboard/logout"
 
 const OnboardResetPassword = "/v2/onboard/password/reset"
 const OnboardForgotPassword = "/v2/onboard/password/forgot"

--- a/internal/http_path/v2/routes.go
+++ b/internal/http_path/v2/routes.go
@@ -140,6 +140,7 @@ func SetRoutes(r *mux.Router, e *casbin.Enforcer) {
 	r.Handle(LoginAdminUser, m.Chain(onboardHandler.LoginAdminUser, m.LoggerNoAuth(), m.AddContentType())).Methods("POST")
 	r.Handle(LoginUser, m.Chain(onboardHandler.LoginUser, m.LoggerNoAuth(), m.AddContentType())).Methods("POST")
 	r.Handle(OnboardResetPassword, m.Chain(onboardHandler.OnboardResetPassword, m.Logger(), m.Authorize(e), m.SetApplicationMode(), m.Authenticate(), m.AddContentType())).Methods("PUT")
+	r.Handle(OnboardLogoutUser, m.Chain(onboardHandler.OnboardLogoutUser, m.Logger(), m.Authorize(e), m.SetApplicationMode(), m.Authenticate(), m.AddContentType())).Methods("POST")
 
 	r.Handle(ValidateUserEmail, m.Chain(onboardHandler.ValidateUserEmail, m.LoggerNoAuth(), m.AddContentType())).Methods("POST")
 	r.Handle(ValidatePhoneNumber, m.Chain(onboardHandler.ValidatePhoneNumber, m.LoggerNoAuth(), m.AddContentType())).Methods("POST")

--- a/internal/iam/iam.go
+++ b/internal/iam/iam.go
@@ -183,3 +183,12 @@ func UnregisterIndividual(iamUserID string) error {
 	err = client.DeleteUser(context.Background(), token.AccessToken, IamConfig.Realm, iamUserID)
 	return err
 }
+
+// LogoutUser logout user
+func LogoutUser(accessToken string, refreshToken string) error {
+	client := GetClient()
+
+	err := client.LogoutPublicClient(context.Background(), IamConfig.ClientId, IamConfig.Realm, accessToken, refreshToken)
+
+	return err
+}

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -85,6 +85,8 @@ func GetRbacPolicies() [][]string {
 		{"user", "/v2/service/individual/{individualId}", "(GET)|(PUT)"},
 		{"user", "/v2/service/image/{imageId}", "GET"},
 		{"user", "/v2/service/individual/record", "DELETE"},
+		{"user", "/v2/onboard/logout", "POST"},
+		{"organisation_admin", "/v2/onboard/logout", "POST"},
 	}
 
 	return policies


### PR DESCRIPTION
JWT access tokens are stateless and do not become invalidated when a user logs out. An API will continue to accept them.

You can revoke a refresh token at any time, including upon logout. The next time a party attempts to use the refresh token to get an access token, it will fail.