### PR TITLE
Fix #631: Ability to configure data sources when defining data agreement

### DIFF
--- a/internal/dataagreement/dataagreements.go
+++ b/internal/dataagreement/dataagreements.go
@@ -49,6 +49,13 @@ type Controller struct {
 	Url  string `json:"url"`
 }
 
+type DataSource struct {
+	Name                string `json:"name" validate:"required"`
+	Sector              string `json:"sector" validate:"required"`
+	Location            string `json:"location" validate:"required"`
+	PrivacyDashboardUrl string `json:"privacyDashboardUrl"`
+}
+
 type DataAgreement struct {
 	Id                      string          `json:"id" bson:"_id,omitempty"`
 	Version                 string          `json:"version"`
@@ -75,6 +82,7 @@ type DataAgreement struct {
 	Dpia                    string          `json:"dpia"`
 	CompatibleWithVersion   string          `json:"compatibleWithVersion"`
 	Controller              Controller      `json:"controller"`
+	DataSources             []DataSource    `json:"dataSources"`
 }
 
 type DataAgreementWithObjectData struct {

--- a/internal/handler/v2/config/dataagreement/config_update_dataagreement.go
+++ b/internal/handler/v2/config/dataagreement/config_update_dataagreement.go
@@ -53,6 +53,14 @@ func validateUpdateDataAgreementRequestBody(dataAgreementReq updateDataAgreement
 		return errors.New("invalid data use provided")
 	}
 
+	if strings.TrimSpace(dataAgreementReq.DataAgreement.DataUse) == "data_using_service" || strings.TrimSpace(dataAgreementReq.DataAgreement.MethodOfUse) == "data_using_service" {
+		for _, dataSource := range dataAgreementReq.DataAgreement.DataSources {
+			if err := validate.Struct(dataSource); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 
@@ -152,6 +160,14 @@ func updateDataAgreementFromRequestBody(requestBody updateDataAgreementReq, toBe
 		toBeUpdatedDataAgreement.MethodOfUse = requestBody.DataAgreement.DataUse
 	} else {
 		toBeUpdatedDataAgreement.DataUse = requestBody.DataAgreement.MethodOfUse
+	}
+
+	if toBeUpdatedDataAgreement.DataUse == "data_using_service" {
+		dataSources := setDataAgreementDusDataSource(requestBody.DataAgreement.DataSources)
+		toBeUpdatedDataAgreement.DataSources = dataSources
+	} else {
+		dataSources := []dataagreement.DataSource{}
+		toBeUpdatedDataAgreement.DataSources = dataSources
 	}
 
 	return toBeUpdatedDataAgreement

--- a/internal/revision/revisions.go
+++ b/internal/revision/revisions.go
@@ -278,6 +278,7 @@ type dataAgreementForObjectData struct {
 	Dpia                    string                        `json:"dpia"`
 	CompatibleWithVersion   string                        `json:"compatibleWithVersion"`
 	Controller              dataagreement.Controller      `json:"controller"`
+	DataSources             []dataagreement.DataSource    `json:"dataSources"`
 }
 
 // InitForDraftDataAgreement
@@ -317,6 +318,7 @@ func CreateRevisionForDataAgreement(newDataAgreement dataagreement.DataAgreement
 		CompatibleWithVersion:   newDataAgreement.CompatibleWithVersion,
 		ControllerName:          newDataAgreement.ControllerName,
 		Controller:              newDataAgreement.Controller,
+		DataSources:             newDataAgreement.DataSources,
 	}
 
 	// Create revision
@@ -353,6 +355,7 @@ func UpdateRevisionForDataAgreement(updatedDataAgreement dataagreement.DataAgree
 		CompatibleWithVersion:   updatedDataAgreement.CompatibleWithVersion,
 		ControllerName:          updatedDataAgreement.ControllerName,
 		Controller:              updatedDataAgreement.Controller,
+		DataSources:             updatedDataAgreement.DataSources,
 	}
 
 	// Initialise revision
@@ -435,6 +438,7 @@ func CreateRevisionForDraftDataAgreement(newDataAgreement dataagreement.DataAgre
 		CompatibleWithVersion:   newDataAgreement.CompatibleWithVersion,
 		ControllerName:          newDataAgreement.ControllerName,
 		Controller:              newDataAgreement.Controller,
+		DataSources:             newDataAgreement.DataSources,
 	}
 
 	// Create revision


### PR DESCRIPTION
#### Steps to test this PR

Run the following commands from `bb-consent-playground` repository:
  
1. To destroy all the running containers and their volumes, execute `make destroy`
2. To build fixtures docker image, execute `make build-fixtures`
3. To build BDD test runner docker image, execute `make build-test`
4. In the API repository, switch to the feature/fix branch you wish to execute tests against and build a docker image by executing `make build/docker/deployable`
5. Copy image name and paste it in `image` field value under `api` in `test-docker-compose.yaml` file inside `test` folder in `bb-consent-playground`
